### PR TITLE
migrate from serde_yml to serde-yaml-ng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
  "anyhow",
  "matrix-sdk",
  "serde",
- "serde_yml",
+ "serde_yaml_ng",
  "tokio",
  "urlencoding",
 ]
@@ -1748,16 +1748,6 @@ checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
 ]
 
 [[package]]
@@ -3291,18 +3281,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4058,6 +4046,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ readme = "README.md"
 anyhow = "1.0"
 matrix-sdk = "0.14"
 serde = { version = "1.0", features = ["derive"] }
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10"
 tokio = { version = "1.47", features = ["full"] }
 urlencoding = "2.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ async fn on_room_message(
 #[tokio::main]
 async fn main() -> Result<()> {
     let config_file = args().nth(1).unwrap_or_else(|| "config.yaml".into());
-    let args: Config = serde_yml::from_reader(
+    let args: Config = serde_yaml_ng::from_reader(
         std::fs::File::open(&config_file)
             .unwrap_or_else(|_| panic!("File not found -- {}", &config_file)),
     )


### PR DESCRIPTION
Replace serde_yml with serde_yaml_ng for YAML parsing. serde-yaml-ng is a maintained fork that provides better performance and continued development.